### PR TITLE
Add FolderIconSO to create list of folder names

### DIFF
--- a/Assets/SimpleFolderIcon/Editor/FolderIconSO.cs
+++ b/Assets/SimpleFolderIcon/Editor/FolderIconSO.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SimpleFolderIcon.Editor 
+{
+    //[CreateAssetMenu()]
+    public class FolderIconSO : ScriptableObject {
+
+        public Texture2D icon;
+        public List<string> folderNames;
+
+        public void OnValidate() {
+            IconDictionaryCreator.BuildDictionary();
+        }
+    }
+}
+

--- a/Assets/SimpleFolderIcon/Editor/FolderIconSO.cs.meta
+++ b/Assets/SimpleFolderIcon/Editor/FolderIconSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1924e497ac37414e91f1284e084dc52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SimpleFolderIcon/Editor/IconDictionaryCreator.cs
+++ b/Assets/SimpleFolderIcon/Editor/IconDictionaryCreator.cs
@@ -52,6 +52,25 @@ namespace SimpleFolderIcon.Editor
                 dictionary.Add(Path.GetFileNameWithoutExtension(f.Name),texture);
             }
 
+            FileInfo[] infoSO = dir.GetFiles("*.asset");
+            foreach (FileInfo f in infoSO) 
+            {
+                var folderIconSO = (FolderIconSO)AssetDatabase.LoadAssetAtPath($"Assets/SimpleFolderIcon/Icons/{f.Name}", typeof(FolderIconSO));
+
+                if (folderIconSO != null) 
+                {
+                    var texture = (Texture)folderIconSO.icon;
+
+                    foreach (string folderName in folderIconSO.folderNames) 
+                    {
+                        if (folderName != null) 
+                        {
+                            dictionary.TryAdd(folderName, texture);
+                        }
+                    }
+                }
+            }
+            
             IconDictionary = dictionary;
         }
     }

--- a/Assets/SimpleFolderIcon/Icons/Default/FolderIconSO.asset
+++ b/Assets/SimpleFolderIcon/Icons/Default/FolderIconSO.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1924e497ac37414e91f1284e084dc52, type: 3}
+  m_Name: FolderIconSO
+  m_EditorClassIdentifier: 
+  icon: {fileID: 2800000, guid: 528e0cfe91970b64f9bf00466d825ed5, type: 3}
+  folderNames: []

--- a/Assets/SimpleFolderIcon/Icons/Default/FolderIconSO.asset.meta
+++ b/Assets/SimpleFolderIcon/Icons/Default/FolderIconSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8e3708225a43174fa8a6bd512e2e077
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The preferred size of the image is **256x256**.
 
 File names of the icon images in `Assets/SimpleFolderIcon/Icons/` are associated with the names of the folder that will be customize.
 
+Optional: if you want to use one image for multiple folders, you may copy `Assets/SimpleFolderIcon/Icons/Default/FolderIconSO.asset` into `Assets/SimpleFolderIcon/Icons/`, then in the Inspector: assign an icon & add as many folder names to the list as you want.
+
 **Just simply customize the icons by renaming or deleting the sample image files!**
 
 ## Requirement


### PR DESCRIPTION
Add Scriptable Object FolderIconSO with
- icon to assign
- list of folder names to use assigned icon

If you want to use one image for multiple folders, you may copy `Assets/SimpleFolderIcon/Icons/Default/FolderIconSO.asset` into `Assets/SimpleFolderIcon/Icons/`, then in the Inspector: assign an icon & add as many folder names to the list as you want.

It is prevents from copying one .png many times, when it needs to be used for many folders.